### PR TITLE
Undefined productCustomAttributes errors on PDP

### DIFF
--- a/src/pages/product/index.js
+++ b/src/pages/product/index.js
@@ -45,7 +45,8 @@ export const ProductDetails = () => {
   useEffect(() => {
     ;(async () => {
       if (!product.data) return
-      const brandId = product.data.mixins.productCustomAttributes.brand
+      const brandId = product.data.mixins.productCustomAttributes?.brand
+      if (!brandId) return
       const brand = await getBrand(brandId)
       setBrand(brand)
     })()
@@ -54,7 +55,7 @@ export const ProductDetails = () => {
   useEffect(() => {
     ;(async () => {
       if (!product.data) return
-      const lableIds = product.data.mixins.productCustomAttributes.labels
+      const lableIds = product.data.mixins.productCustomAttributes?.labels
       if (lableIds && lableIds.length > 0) {
         const labels = await Promise.all(
           lableIds.map(async (labelId) => {


### PR DESCRIPTION
Make brandId fail proof, fix undefined error if a product doesn't have a productCustomAttributes object